### PR TITLE
Add from tag back into release notes generator

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -13,9 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: actions/checkout@v3
       with:
-        repository: WISE-Developers/versions
+        repository: WISE-Developers/WISE_Versions
         path: versions
         token: ${{ secrets.WISE_PAT }}
     - name: Set up JDK 8
@@ -30,8 +32,8 @@ jobs:
       shell: pwsh
       run: |
         $versions = ConvertFrom-StringData (Get-Content versions/versions.properties -raw)
-        echo "Updating to version $($versions.prometheus)"
-        echo "prometheus_version=$($versions.prometheus)" >> $env:GITHUB_OUTPUT
+        echo "Updating to version $($versions.wise)"
+        echo "prometheus_version=$($versions.wise)" >> $env:GITHUB_OUTPUT
       
     - name: Update the version
       run: mvn versions:set -DnewVersion=${{ steps.version-numbers.outputs.prometheus_version }}
@@ -49,6 +51,8 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
+        LAST_TAG=$(git describe --abbrev=0 --tags)
+        echo "last_tag=$LAST_TAG" >> $GITHUB_OUTPUT
         git tag -a ${{ steps.version-numbers.outputs.prometheus_version }} -m "Release on $(date +'%Y-%m-%d') for commit $(git rev-parse HEAD)"
   
     - name: Push changes
@@ -63,7 +67,7 @@ jobs:
         owner: WISE-Developers
         repo: WISE_Java_API
         toTag: ${{ steps.version-numbers.outputs.prometheus_version }}
-#         fromTag: ${{ steps.last-tags.outputs.last_tag }}
+        fromTag: ${{ steps.last-tags.outputs.last_tag }}
       env:
         GITHUB_TOKEN: ${{ secrets.WISE_PAT }}
     


### PR DESCRIPTION
The from tag had to be removed from the first release because there were no tags to retrieve at that point. It can be added back in now that a release has been made.

Part of WISE-Developers/Project_Issues#184.